### PR TITLE
Fix DTO Converter when using implementation type directly

### DIFF
--- a/Remora.Rest/Json/Internal/BoundDataObjectConverter.cs
+++ b/Remora.Rest/Json/Internal/BoundDataObjectConverter.cs
@@ -33,12 +33,10 @@ namespace Remora.Rest.Json.Internal;
 /// The actual implementation of <see cref="DataObjectConverter{TInterface, TImplementation}"/>, created by that same type.
 /// These instances are bound to a certain set of <see cref="JsonSerializerOptions"/> and cache any data it might need.
 /// </summary>
-/// <typeparam name="TInterface">The interface that is seen in the objects.</typeparam>
-/// <typeparam name="TImplementation">The concrete implementation.</typeparam>
-internal sealed class BoundDataObjectConverter<TInterface, TImplementation> : JsonConverter<TInterface>
-    where TImplementation : TInterface
+/// <typeparam name="T">The type this instance converts.</typeparam>
+internal sealed class BoundDataObjectConverter<T> : JsonConverter<T>
 {
-    private readonly ObjectFactory<TInterface> _dtoFactory;
+    private readonly ObjectFactory<T> _dtoFactory;
     private readonly bool _allowExtraProperties;
 
     // Split the property list to avoid "CanWrite" checks everywhere and instead perform that preemptively
@@ -52,14 +50,8 @@ internal sealed class BoundDataObjectConverter<TInterface, TImplementation> : Js
     // Speed up looking up the correct property. Also implicitly means property names can't be duplicated
     private readonly Dictionary<string, (bool IsPrimary, DTOPropertyInfo DTOProperty)> _readPropertiesByName;
 
-    /// <inheritdoc />
-    public override bool CanConvert(Type typeToConvert)
-    {
-        return typeToConvert == typeof(TImplementation) || base.CanConvert(typeToConvert);
-    }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="BoundDataObjectConverter{TInterface, TImplementation}"/> class.
+    /// Initializes a new instance of the <see cref="BoundDataObjectConverter{T}"/> class.
     /// </summary>
     /// <param name="dtoFactory">The DTO factory.</param>
     /// <param name="allowExtraProperties">Whether extra undefined properties should be allowed.</param>
@@ -67,7 +59,7 @@ internal sealed class BoundDataObjectConverter<TInterface, TImplementation> : Js
     /// <param name="readProperties">Properties relevant when reading the DTO from JSON.</param>
     public BoundDataObjectConverter
     (
-        ObjectFactory<TInterface> dtoFactory,
+        ObjectFactory<T> dtoFactory,
         bool allowExtraProperties,
         DTOPropertyInfo[] writeProperties,
         DTOPropertyInfo[] readProperties
@@ -84,7 +76,7 @@ internal sealed class BoundDataObjectConverter<TInterface, TImplementation> : Js
     }
 
     /// <inheritdoc />
-    public override TInterface Read
+    public override T Read
     (
         ref Utf8JsonReader reader,
         Type typeToConvert,
@@ -186,7 +178,7 @@ internal sealed class BoundDataObjectConverter<TInterface, TImplementation> : Js
     public override void Write
     (
         Utf8JsonWriter writer,
-        TInterface value,
+        T value,
         JsonSerializerOptions options
     )
     {

--- a/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
+++ b/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
@@ -93,7 +93,7 @@ internal static class ExpressionFactoryUtilities
             );
         }
 
-        if (constructor.DeclaringType.IsAssignableFrom(typeof(T)))
+        if (!typeof(T).IsAssignableFrom(constructor.DeclaringType))
         {
             throw new ArgumentException
             (

--- a/Tests/Remora.Rest.Tests/Tests/Json/DataObjectConverterTests.cs
+++ b/Tests/Remora.Rest.Tests/Tests/Json/DataObjectConverterTests.cs
@@ -422,4 +422,53 @@ public class DataObjectConverterTests
         var serialized = JsonDocument.Parse(JsonSerializer.Serialize(value, jsonOptions));
         JsonAssert.Equivalent(expectedPayload, serialized);
     }
+
+    /// <summary>
+    /// Tests whether the converter can correctly serialize its data if provided as the implementation type.
+    /// </summary>
+    [Fact]
+    public void CanSerializeAsConcreteType()
+    {
+        var services = new ServiceCollection()
+            .Configure<JsonSerializerOptions>
+            (
+                json =>
+                {
+                    json.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+                    json.AddDataObjectConverter<ISimpleData, SimpleData>();
+                })
+            .BuildServiceProvider();
+
+        var jsonOptions = services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
+
+        SimpleData value = new SimpleData("booga");
+        var expectedPayload = JsonDocument.Parse("{ \"value\": \"booga\" }");
+
+        var serialized = JsonDocument.Parse(JsonSerializer.Serialize(value, jsonOptions));
+        JsonAssert.Equivalent(expectedPayload, serialized);
+    }
+
+    /// <summary>
+    /// Tests whether the converter can correctly deserialize its data if provided as the implementation type.
+    /// </summary>
+    [Fact]
+    public void CanDeserializeToConcreteType()
+    {
+        var services = new ServiceCollection()
+            .Configure<JsonSerializerOptions>
+            (
+                json =>
+                {
+                    json.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+                    json.AddDataObjectConverter<ISimpleData, SimpleData>();
+                })
+            .BuildServiceProvider();
+
+        var jsonOptions = services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
+        var payload = "{ \"value\": \"booga\" }";
+
+        var value = JsonSerializer.Deserialize<SimpleData>(payload, jsonOptions);
+        Assert.NotNull(value);
+        Assert.Equal("booga", value.Value);
+    }
 }


### PR DESCRIPTION
Turns out I introduced a subtle bug in https://github.com/Remora/Remora.Rest/pull/13.

The DTO converter factory claims it can convert the implementation type, but trying to do so directly will fail on STJ's level.
(Seems like converters returned by factories are expected to _exactly_ match the type provided.)

By "directly", I mean situations like `JsonSerializer.Deserialize<TImplementation>(...)` or simply specifying the implementation type instead of the interface in a DTO otherwise.

This is definitely not the intended pattern, but it used to work and the factory still claims it's supported through its `CanConvert` method.

That said, this PR makes the DTOConverter return a converter for the correct type and adds tests to assert doing the above works.

(Regarding the change in `ExpressionFactoryUtilities`, the previous check used to fail if `typeof(T) == DeclaringType`.)