### PR TITLE
Add Span-based overloads of IsPNG, IsGIF, IsJPG

### DIFF
--- a/Remora.Rest/Extensions/TypeDetectionExtensions.cs
+++ b/Remora.Rest/Extensions/TypeDetectionExtensions.cs
@@ -20,6 +20,8 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
+
 namespace Remora.Rest.Extensions;
 
 /// <summary>
@@ -33,6 +35,28 @@ public static class TypeDetectionExtensions
     /// <param name="array">The array.</param>
     /// <returns>true if the array contains PNG data; otherwise, false.</returns>
     public static bool IsPNG(this byte[] array)
+    {
+        if (array.Length < 8)
+        {
+            return false;
+        }
+
+        return array[0] == 0x89 &&
+               array[1] == 0x50 &&
+               array[2] == 0x4E &&
+               array[3] == 0x47 &&
+               array[4] == 0x0D &&
+               array[5] == 0x0A &&
+               array[6] == 0x1A &&
+               array[7] == 0x0A;
+    }
+
+    /// <summary>
+    /// Determines whether the span is a view over PNG data.
+    /// </summary>
+    /// <param name="array">The span.</param>
+    /// <returns>true if the span contains PNG data; otherwise, false.</returns>
+    public static bool IsPNG(this ReadOnlySpan<byte> array)
     {
         if (array.Length < 8)
         {
@@ -65,11 +89,41 @@ public static class TypeDetectionExtensions
     }
 
     /// <summary>
+    /// Determines whether the span is a view over GIF data.
+    /// </summary>
+    /// <param name="array">The span.</param>
+    /// <returns>true if the span contains GIF data; otherwise, false.</returns>
+    public static bool IsGIF(this ReadOnlySpan<byte> array)
+    {
+        if (array.Length < 3)
+        {
+            return false;
+        }
+
+        return array[0] == 0x47 && array[1] == 0x49 && array[2] == 0x46;
+    }
+
+    /// <summary>
     /// Determines whether the array contains JPG data.
     /// </summary>
     /// <param name="array">The array.</param>
     /// <returns>true if the array contains JPG data; otherwise, false.</returns>
     public static bool IsJPG(this byte[] array)
+    {
+        if (array.Length < 3)
+        {
+            return false;
+        }
+
+        return array[0] == 0xFF && array[1] == 0xD8 && array[2] == 0xFF;
+    }
+
+    /// <summary>
+    /// Determines whether the span is a view over JPG data.
+    /// </summary>
+    /// <param name="array">The span.</param>
+    /// <returns>true if the span contains JPG data; otherwise, false.</returns>
+    public static bool IsJPG(this ReadOnlySpan<byte> array)
     {
         if (array.Length < 3)
         {

--- a/Remora.Rest/Extensions/TypeDetectionExtensions.cs
+++ b/Remora.Rest/Extensions/TypeDetectionExtensions.cs
@@ -34,22 +34,7 @@ public static class TypeDetectionExtensions
     /// </summary>
     /// <param name="array">The array.</param>
     /// <returns>true if the array contains PNG data; otherwise, false.</returns>
-    public static bool IsPNG(this byte[] array)
-    {
-        if (array.Length < 8)
-        {
-            return false;
-        }
-
-        return array[0] == 0x89 &&
-               array[1] == 0x50 &&
-               array[2] == 0x4E &&
-               array[3] == 0x47 &&
-               array[4] == 0x0D &&
-               array[5] == 0x0A &&
-               array[6] == 0x1A &&
-               array[7] == 0x0A;
-    }
+    public static bool IsPNG(this byte[] array) => IsPNG(array.AsSpan());
 
     /// <summary>
     /// Determines whether the span is a view over PNG data.
@@ -78,15 +63,7 @@ public static class TypeDetectionExtensions
     /// </summary>
     /// <param name="array">The array.</param>
     /// <returns>true if the array contains GIF data; otherwise, false.</returns>
-    public static bool IsGIF(this byte[] array)
-    {
-        if (array.Length < 3)
-        {
-            return false;
-        }
-
-        return array[0] == 0x47 && array[1] == 0x49 && array[2] == 0x46;
-    }
+    public static bool IsGIF(this byte[] array) => IsGIF(array.AsSpan());
 
     /// <summary>
     /// Determines whether the span is a view over GIF data.
@@ -108,15 +85,7 @@ public static class TypeDetectionExtensions
     /// </summary>
     /// <param name="array">The array.</param>
     /// <returns>true if the array contains JPG data; otherwise, false.</returns>
-    public static bool IsJPG(this byte[] array)
-    {
-        if (array.Length < 3)
-        {
-            return false;
-        }
-
-        return array[0] == 0xFF && array[1] == 0xD8 && array[2] == 0xFF;
-    }
+    public static bool IsJPG(this byte[] array) => IsJPG(array.AsSpan());
 
     /// <summary>
     /// Determines whether the span is a view over JPG data.


### PR DESCRIPTION
Adds Span-based overloads of the extension methods in TypeDetectionExtensions. I haven't removed the existing `byte[]` methods as that would break binary compatibility and possibly source compatibility (not sure on the latter).