### PR TITLE
Add many Optional<T> helper methods

### DIFF
--- a/Remora.Rest.Core/OptionalExtensions.cs
+++ b/Remora.Rest.Core/OptionalExtensions.cs
@@ -1,0 +1,83 @@
+﻿//
+//  OptionalExtensions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Rest.Core;
+
+/// <summary>
+/// Contains extension methods for <see cref="Optional{TValue}"/>.
+/// </summary>
+public static class OptionalExtensions
+{
+    // These methods have to be an extension because they take Optional<T?> as the type of `this`
+
+    /// <summary>
+    /// Converts an <see cref="Optional{TValue}"/> with a null value to an Optional with no value; otherwise, returns
+    /// the unmodified <see cref="Optional{TValue}"/>.
+    /// </summary>
+    /// <param name="optional">The optional.</param>
+    /// <typeparam name="T">The resulting optional's type.</typeparam>
+    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
+    public static Optional<T> ConvertNullToEmpty<T>(this Optional<T?> optional) where T : class
+    {
+        return optional.IsDefined(out var value)
+            ? new Optional<T>(value)
+            : default;
+    }
+
+    /// <summary>
+    /// Converts an <see cref="Optional{TValue}"/> with a null value to an Optional with no value; otherwise, returns
+    /// the unmodified <see cref="Optional{TValue}"/>.
+    /// </summary>
+    /// <param name="optional">The optional.</param>
+    /// <typeparam name="T">The resulting optional's type.</typeparam>
+    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
+    public static Optional<T> ConvertNullToEmpty<T>(this Optional<T?> optional) where T : struct
+    {
+        return optional.IsDefined(out var value)
+            ? new Optional<T>(value.Value)
+            : default;
+    }
+
+    /// <summary>
+    /// Converts a nullable value to a non-nullable <see cref="Optional{TValue}"/> which is empty if the input value is
+    /// <c>null</c>.
+    /// </summary>
+    /// <param name="nullable">The nullable input value.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
+    public static Optional<T> AsOptional<T>(this T? nullable) where T : struct
+    {
+        return nullable is { } value ? new Optional<T>(value) : default;
+    }
+
+    /// <summary>
+    /// Converts a nullable value to a non-nullable <see cref="Optional{TValue}"/> which is empty if the input value is
+    /// <c>null</c>.
+    /// </summary>
+    /// <param name="nullable">The nullable input value.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
+    public static Optional<T> AsOptional<T>(this T? nullable) where T : class
+    {
+        return nullable != null ? new Optional<T>(nullable) : default;
+    }
+}


### PR DESCRIPTION
Adds several utility methods to `Optional<T>`:

- `Optional.Empty<T>`: shortcut for `new Optional<T>()` but the compiler may sometimes infer the generic type making it optional.
- `Optional.From<T>`: shortcut for `new Optional<T>(value)` but the compiler may sometimes infer the generic type making it optional.
- `OrDefault`: Gets the value of an `Optional<T>` or `default` if there is no value.
- `OrThrow`: Gets the value of an `Optional<T>` or throws an user-defined exception if there is no value.
- `Nullable`: Casts `Optional<T>` to `Optional<T?>`
- `TryGet`: Counterpart to `IsDefined(out TValue value)` except considers null optional values as valid
- `Map<TResult>`: Maps an `Optional<T>` into `Optional<TResult>` with a mapping function
- `ConvertNullToEmpty`: Converts an `Optional<T?>` into an `Optional<T>` that is empty if the value is null
- `T?.AsOptional`: Converts a nullable value into an `Optional<T>`

Also adds DebuggerDisplay for `Optional<T>`