### PR TITLE
Add tests for new Optional<T> helper methods

### DIFF
--- a/Remora.Rest.Core/Optional.cs
+++ b/Remora.Rest.Core/Optional.cs
@@ -161,7 +161,7 @@ public readonly struct Optional<TValue> : IOptional
 
     /// <summary>
     /// Returns the value of the current <see cref="Optional{TValue}"/>, or <c>default</c> if the current
-    /// <see cref="Optional{TValue}"/> is empty.
+    /// <see cref="Optional{TValue}"/> has no value.
     /// </summary>
     /// <returns>The value of <c>this</c> or <c>default</c> if none is present.</returns>
     public TValue? OrDefault()
@@ -173,7 +173,7 @@ public readonly struct Optional<TValue> : IOptional
 
     /// <summary>
     /// Returns the value of the current <see cref="Optional{TValue}"/>, or <paramref name="defaultValue"/> if
-    /// <see cref="Optional{TValue}"/> is <b>null or empty</b>.
+    /// <see cref="Optional{TValue}"/> has no value or its value is null.
     /// </summary>
     /// <param name="defaultValue">The default value to fallback to if the optional is empty.</param>
     /// <returns>
@@ -189,11 +189,11 @@ public readonly struct Optional<TValue> : IOptional
 
     /// <summary>
     /// Returns the value of the current <see cref="Optional{TValue}"/>, or throws the exception in
-    /// <paramref name="func"/> if empty.
+    /// <paramref name="func"/> if the current <see cref="Optional{TValue}"/> has no value.
     /// </summary>
     /// <param name="func">The function generating an <see cref="Exception"/>.</param>
     /// <returns>The value of <see cref="Optional{TValue}"/>.</returns>
-    /// <exception cref="Exception">If <see cref="Optional{TValue}"/> is empty.</exception>
+    /// <exception cref="Exception">If <see cref="Optional{TValue}"/> has no value.</exception>
     // Compile-time optimization: taking an Exception here would lead to an allocation on every call; taking a static
     // Delegate that produces an Exception only allocates in the failing case.
     public TValue OrThrow([RequireStaticDelegate] Func<Exception> func)
@@ -238,12 +238,12 @@ public readonly struct Optional<TValue> : IOptional
 
     /// <summary>
     /// Applies a mapping function to the value of the <see cref="Optional{TValue}"/> if it has one; otherwise, returns
-    /// a new empty <see cref="Optional{TValue}"/> of the resulting type.
+    /// a new <see cref="Optional{TValue}"/> of the resulting type with no value.
     /// </summary>
     /// <param name="mappingFunc">The mapping function.</param>
     /// <typeparam name="TResult">The value type for the output of the mapping result.</typeparam>
     /// <returns>
-    /// A new optional with the mapping result if <see cref="Optional{TValue}"/> is non-empty; an empty optional
+    /// A new optional with the mapping result if <see cref="Optional{TValue}"/> has a value; an optional with no value
     /// otherwise.
     /// </returns>
     public Optional<TResult> Map<TResult>(Func<TValue, TResult> mappingFunc)

--- a/Remora.Rest.Core/Optional.cs
+++ b/Remora.Rest.Core/Optional.cs
@@ -166,7 +166,7 @@ public readonly struct Optional<TValue> : IOptional
     /// <returns>The value of <c>this</c> or <c>default</c> if none is present.</returns>
     public TValue? OrDefault()
     {
-        return TryGet(out var value)
+        return IsDefined(out var value)
             ? value
             : default;
     }

--- a/Remora.Rest.Core/Optional.cs
+++ b/Remora.Rest.Core/Optional.cs
@@ -204,19 +204,6 @@ public readonly struct Optional<TValue> : IOptional
     }
 
     /// <summary>
-    /// Casts the current <see cref="Optional{TValue}"/> to a nullable <typeparamref name="TValue"/>?.
-    /// </summary>
-    /// <returns>
-    /// An <see cref="Optional{TValue}"/> with the type parameter changed to <typeparamref name="TValue"/>?.
-    /// </returns>
-    public Optional<TValue?> AsNullableOptional()
-    {
-        return TryGet(out var value)
-            ? value
-            : default(Optional<TValue?>);
-    }
-
-    /// <summary>
     /// Gets the underlying value of a <see cref="Optional{TValue}"/> if it has one.
     /// </summary>
     /// <param name="value">

--- a/Remora.Rest.Core/OptionalExtensionsClass.cs
+++ b/Remora.Rest.Core/OptionalExtensionsClass.cs
@@ -1,5 +1,5 @@
 ﻿//
-//  OptionalExtensions.cs
+//  OptionalExtensionsClass.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -28,48 +28,33 @@ namespace Remora.Rest.Core;
 /// Contains extension methods for <see cref="Optional{TValue}"/>.
 /// </summary>
 [PublicAPI]
-public static class OptionalExtensions
+public static class OptionalExtensionsClass
 {
-    // These methods have to be an extension because they take Optional<T?> as the type of `this`
+    /// <summary>
+    /// Casts the current <see cref="Optional{TValue}"/> to a nullable <typeparamref name="T"/>?.
+    /// </summary>
+    /// <param name="optional">The optional.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>
+    /// An <see cref="Optional{TValue}"/> with the type parameter changed to <typeparamref name="T"/>?.
+    /// </returns>
+    public static Optional<T?> AsNullableOptional<T>(this Optional<T> optional) where T : class
+    {
+        return optional.TryGet(out var value)
+            ? value
+            : default(Optional<T?>);
+    }
 
     /// <summary>
     /// Converts an <see cref="Optional{TValue}"/> with a null value to an Optional with no value; otherwise, returns
     /// the unmodified <see cref="Optional{TValue}"/>.
     /// </summary>
     /// <param name="optional">The optional.</param>
-    /// <typeparam name="T">The resulting optional's type.</typeparam>
+    /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>The <see cref="Optional{TValue}"/>.</returns>
     public static Optional<T> ConvertNullToEmpty<T>(this Optional<T?> optional) where T : class
     {
         return optional.IsDefined(out var value)
-            ? new Optional<T>(value)
-            : default;
-    }
-
-    /// <summary>
-    /// Converts an <see cref="Optional{TValue}"/> with a null value to an Optional with no value; otherwise, returns
-    /// the unmodified <see cref="Optional{TValue}"/>.
-    /// </summary>
-    /// <param name="optional">The optional.</param>
-    /// <typeparam name="T">The resulting optional's type.</typeparam>
-    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
-    public static Optional<T> ConvertNullToEmpty<T>(this Optional<T?> optional) where T : struct
-    {
-        return optional.IsDefined(out var value)
-            ? new Optional<T>(value.Value)
-            : default;
-    }
-
-    /// <summary>
-    /// Converts a nullable value to a non-nullable <see cref="Optional{TValue}"/> which is empty if the input value is
-    /// <c>null</c>.
-    /// </summary>
-    /// <param name="nullable">The nullable input value.</param>
-    /// <typeparam name="T">The type of the value.</typeparam>
-    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
-    public static Optional<T> AsOptional<T>(this T? nullable) where T : struct
-    {
-        return nullable is { } value
             ? new Optional<T>(value)
             : default;
     }

--- a/Remora.Rest.Core/OptionalExtensionsStruct.cs
+++ b/Remora.Rest.Core/OptionalExtensionsStruct.cs
@@ -1,0 +1,75 @@
+//
+//  OptionalExtensionsStruct.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Rest.Core;
+
+/// <summary>
+/// Contains extension methods for <see cref="Optional{TValue}"/>.
+/// </summary>
+[PublicAPI]
+public static class OptionalExtensionsStruct
+{
+    /// <summary>
+    /// Casts the current <see cref="Optional{TValue}"/> to a nullable <typeparamref name="T"/>?.
+    /// </summary>
+    /// <param name="optional">The optional.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>
+    /// An <see cref="Optional{TValue}"/> with the type parameter changed to <typeparamref name="T"/>?.
+    /// </returns>
+    public static Optional<T?> AsNullableOptional<T>(this Optional<T> optional) where T : struct
+    {
+        return optional.TryGet(out var value)
+            ? value
+            : default(Optional<T?>);
+    }
+
+    /// <summary>
+    /// Converts an <see cref="Optional{TValue}"/> with a null value to an Optional with no value; otherwise, returns
+    /// the unmodified <see cref="Optional{TValue}"/>.
+    /// </summary>
+    /// <param name="optional">The optional.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
+    public static Optional<T> ConvertNullToEmpty<T>(this Optional<T?> optional) where T : struct
+    {
+        return optional.IsDefined(out var value)
+            ? new Optional<T>(value.Value)
+            : default;
+    }
+
+    /// <summary>
+    /// Converts a nullable value to a non-nullable <see cref="Optional{TValue}"/> which is empty if the input value is
+    /// <c>null</c>.
+    /// </summary>
+    /// <param name="nullable">The nullable input value.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>The <see cref="Optional{TValue}"/>.</returns>
+    public static Optional<T> AsOptional<T>(this T? nullable) where T : struct
+    {
+        return nullable is { } value
+            ? new Optional<T>(value)
+            : default;
+    }
+}

--- a/Tests/Remora.Rest.Core.Tests/Optional/OptionalTests.cs
+++ b/Tests/Remora.Rest.Core.Tests/Optional/OptionalTests.cs
@@ -598,7 +598,7 @@ public static class OptionalTests
         public static void ReturnsNullValueForClasses()
         {
             var a = default(Optional<object>);
-            Assert.Equal(null, a.OrDefault());
+            Assert.Null(a.OrDefault());
         }
 
         [Fact]
@@ -636,8 +636,7 @@ public static class OptionalTests
         public static void ThrowsIfDoesNotContainValue()
         {
             var a = default(Optional<int>);
-            Assert.Throws<InvalidOperationException>(()
-                => a.OrThrow(static () => new InvalidOperationException("Expected")));
+            Assert.Throws<InvalidOperationException>(() => a.OrThrow(static () => new InvalidOperationException("Expected")));
         }
 
         [Fact]
@@ -645,8 +644,7 @@ public static class OptionalTests
         {
             Optional<int> a = 1;
 
-            var exception =
-                Record.Exception(() => a.OrThrow(static () => new InvalidOperationException("Not expected")));
+            var exception = Record.Exception(() => a.OrThrow(static () => new InvalidOperationException("Not expected")));
             Assert.Null(exception);
         }
     }

--- a/Tests/Remora.Rest.Core.Tests/Optional/OptionalTests.cs
+++ b/Tests/Remora.Rest.Core.Tests/Optional/OptionalTests.cs
@@ -651,26 +651,54 @@ public static class OptionalTests
 
     public static class AsNullableOptional
     {
-        [Fact]
-        public static void ProducesCorrectValueWhenEmpty()
+        public static class Struct
         {
-            var a = default(Optional<object>);
-            var result = a.AsNullableOptional();
+            [Fact]
+            public static void ProducesCorrectValueWhenEmpty()
+            {
+                var a = default(Optional<int>);
+                var result = a.AsNullableOptional();
 
-            // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
-            Assert.Equal(default(Optional<object?>), result);
-            Assert.False(result.HasValue);
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(default(Optional<int?>), result);
+                Assert.False(result.HasValue);
+            }
+
+            [Fact]
+            public static void ProducesCorrectValueWhenPresent()
+            {
+                Optional<int> a = 1;
+                var result = a.AsNullableOptional();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(new Optional<int?>(1), result);
+                Assert.True(result.HasValue);
+            }
         }
 
-        [Fact]
-        public static void ProducesCorrectValueWhenPresent()
+        public static class Class
         {
-            Optional<string> a = "Hello world";
-            var result = a.AsNullableOptional();
+            [Fact]
+            public static void ProducesCorrectValueWhenEmpty()
+            {
+                var a = default(Optional<object>);
+                var result = a.AsNullableOptional();
 
-            // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
-            Assert.Equal(new Optional<string?>("Hello world"), result);
-            Assert.True(result.HasValue);
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(default(Optional<object?>), result);
+                Assert.False(result.HasValue);
+            }
+
+            [Fact]
+            public static void ProducesCorrectValueWhenPresent()
+            {
+                Optional<string> a = "Hello world";
+                var result = a.AsNullableOptional();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(new Optional<string?>("Hello world"), result);
+                Assert.True(result.HasValue);
+            }
         }
     }
 
@@ -783,6 +811,61 @@ public static class OptionalTests
                 var result = a.ConvertNullToEmpty();
                 Assert.True(result.IsDefined(out var value));
                 Assert.Equal("Expected", value);
+            }
+        }
+    }
+
+    public static class AsOptional
+    {
+        public static class Struct
+        {
+            [Fact]
+            public static void ProducesCorrectValueWhenEmpty()
+            {
+                var a = default(int?);
+                var result = a.AsOptional();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(default(Optional<int>), result);
+                Assert.False(result.HasValue);
+            }
+
+            [Fact]
+            public static void ProducesCorrectValueWhenPresent()
+            {
+                int? a = 1;
+                var result = a.AsOptional();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(new Optional<int>(1), result);
+                Assert.True(result.HasValue);
+            }
+        }
+
+        public static class Class
+        {
+            [Fact]
+            public static void ProducesCorrectValueWhenEmpty()
+            {
+                string? a = null;
+                var result = a.AsOptional();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(default(Optional<string>), result);
+                Assert.False(result.HasValue);
+            }
+
+            [Fact]
+            public static void ProducesCorrectValueWhenPresent()
+            {
+                // ReSharper disable once SuggestVarOrType_BuiltInTypes
+                // ReSharper disable once VariableCanBeNotNullable
+                string? a = "Hello world";
+                var result = a.AsOptional();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(new Optional<string>("Hello world"), result);
+                Assert.True(result.HasValue);
             }
         }
     }


### PR DESCRIPTION
* Add tests for new Optional<T> methods
* Improve documentation clarity and consistency
* Use IsDefined in OrDefault
  * Does not change de-facto behavior, improves code readability
