### PR TITLE
Add Optional<T>.AsNullable extension method

### DIFF
--- a/Remora.Rest.Core/OptionalExtensionsClass.cs
+++ b/Remora.Rest.Core/OptionalExtensionsClass.cs
@@ -72,4 +72,18 @@ public static class OptionalExtensionsClass
             ? new Optional<T>(nullable)
             : default;
     }
+
+    /// <summary>
+    /// Converts an <see cref="Optional{TValue}"/> to a nullable value, which is <c>null</c> if the
+    /// <see cref="Optional{TValue}"/> is null or has no value, and non-null otherwise.
+    /// </summary>
+    /// <param name="optional">The optional input value.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>The nullable value.</returns>
+    public static T? AsNullable<T>(this Optional<T> optional) where T : class
+    {
+        return optional.TryGet(out var value)
+            ? value
+            : null;
+    }
 }

--- a/Remora.Rest.Core/OptionalExtensionsStruct.cs
+++ b/Remora.Rest.Core/OptionalExtensionsStruct.cs
@@ -20,6 +20,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using JetBrains.Annotations;
 
 namespace Remora.Rest.Core;
@@ -71,5 +72,19 @@ public static class OptionalExtensionsStruct
         return nullable is { } value
             ? new Optional<T>(value)
             : default;
+    }
+
+    /// <summary>
+    /// Converts an <see cref="Optional{TValue}"/> to a <see cref="Nullable{T}"/>, which is <c>null</c> if the
+    /// <see cref="Optional{TValue}"/> is null or has no value, and non-null otherwise.
+    /// </summary>
+    /// <param name="optional">The optional input value.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>The nullable value.</returns>
+    public static T? AsNullable<T>(this Optional<T> optional) where T : struct
+    {
+        return optional.TryGet(out var value)
+            ? value
+            : null;
     }
 }

--- a/Tests/Remora.Rest.Core.Tests/Optional/OptionalTests.cs
+++ b/Tests/Remora.Rest.Core.Tests/Optional/OptionalTests.cs
@@ -869,4 +869,57 @@ public static class OptionalTests
             }
         }
     }
+
+    public static class AsNullable
+    {
+        public static class Struct
+        {
+            [Fact]
+            public static void ProducesCorrectValueWhenEmpty()
+            {
+                var a = default(Optional<int>);
+                var result = a.AsNullable();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(default(int?), result);
+                Assert.False(result.HasValue);
+            }
+
+            [Fact]
+            public static void ProducesCorrectValueWhenPresent()
+            {
+                Optional<int> a = 1;
+                var result = a.AsNullable();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal(1, result);
+                Assert.True(result.HasValue);
+            }
+        }
+
+        public static class Class
+        {
+            [Fact]
+            public static void ProducesCorrectValueWhenEmpty()
+            {
+                var a = default(Optional<string>);
+                var result = a.AsNullable();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public static void ProducesCorrectValueWhenPresent()
+            {
+                // ReSharper disable once SuggestVarOrType_BuiltInTypes
+                // ReSharper disable once VariableCanBeNotNullable
+                Optional<string> a = "Hello world";
+                var result = a.AsNullable();
+
+                // ReSharper disable once ArrangeDefaultValueWhenTypeNotEvident
+                Assert.Equal("Hello world", result);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds a counterpart to `T?.AsOptional` that does the opposite operation.