### PR TITLE
Unify DTO default parameter handling

### DIFF
--- a/Remora.Rest/Json/DataObjectConverter.cs
+++ b/Remora.Rest/Json/DataObjectConverter.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -513,12 +514,27 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverterFac
         var writeProperties = new List<DTOPropertyInfo>();
         var readProperties = new List<DTOPropertyInfo>();
 
-        foreach (var property in _dtoProperties)
+        var parameters = _dtoConstructor.GetParameters();
+        var properties = _dtoProperties;
+        for (int i = 0; i < properties.Count; i++)
         {
+            var property = properties[i];
+
+            // Properties are currently sorted to match the parameter order, followed by read-only properties.
+            // As such, we assume that this code will give us the matching parameter for a property.
+            var parameter = (uint)i < (uint)parameters.Length ? parameters[i] : null;
+
+            // Just to be sure, we assert this behavior here. This is essentially how property reordering associated property and parameter.
+            Debug.Assert
+            (
+                parameter == null || (property.Name.Equals(parameter.Name, StringComparison.InvariantCultureIgnoreCase) && property.PropertyType == parameter.ParameterType),
+                "Expectations around property/parameter order are upheld."
+            );
+
             var converter = GetConverter(property, options);
             var propertyOptions = converter == null ? options : CreatePropertyConverterOptions(options, converter);
 
-            var defaultValue = GetDefaultValueForType(property.PropertyType);
+            var defaultValue = parameter == null ? null : GetDefaultValueForParameter(parameter);
             var readNames = GetReadJsonPropertyName(property, options);
             var writeNames = GetWriteJsonPropertyName(property, options);
             var writer = GetPropertyWriter(property);
@@ -557,7 +573,6 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverterFac
             _interfaceDtoFactory ??= ExpressionFactoryUtilities.CreateFactory<TInterface>(_dtoConstructor);
             return new BoundDataObjectConverter<TInterface>
             (
-                _dtoConstructor,
                 _interfaceDtoFactory,
                 _allowExtraProperties,
                 writeProperties.ToArray(),
@@ -571,7 +586,6 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverterFac
             _implementationDtoFactory ??= ExpressionFactoryUtilities.CreateFactory<TImplementation>(_dtoConstructor);
             return new BoundDataObjectConverter<TImplementation>
             (
-                _dtoConstructor,
                 _implementationDtoFactory,
                 _allowExtraProperties,
                 writeProperties.ToArray(),
@@ -664,20 +678,38 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverterFac
     }
 
     /// <summary>
-    /// Gets the default value for a type or <see langword="null"/> if it has no default value.
+    /// Gets the default value for a parameter. If this is an <see cref="Optional{TValue}"/> parameter,
+    /// uses <see langword="default"/> if there is no explicit default.
     /// </summary>
-    /// <remarks>
-    /// This always either <see langword="default"/> for <see cref="Optional{TValue}"/> or <see langword="null"/> for
-    /// any other type.
-    /// </remarks>
-    /// <param name="type">The type to get the default value for.</param>
-    /// <returns>The default value or <see langword="null"/>.</returns>
-    private object? GetDefaultValueForType(Type type)
+    /// <param name="parameter">The parameter to get the default value for.</param>
+    /// <returns>Empty, if there is no default, otherwise the default parameter value.</returns>
+    private Optional<object?> GetDefaultValueForParameter(ParameterInfo parameter)
     {
-        // There currently are only default values for Optional<T> types.
-        // For those, the default value will be the empty instance.
-        // For any other type, this method returns null.
-        return _dtoEmptyOptionals.GetValueOrDefault(type);
+        var type = parameter.ParameterType;
+
+        // If there is an explicit default parameter, we use that.
+        object? defaultValue;
+        if (parameter.HasDefaultValue)
+        {
+            defaultValue = parameter.DefaultValue;
+            if (type.IsValueType && defaultValue is null)
+            {
+                // "default" default parameters for value-types are null here. Instantiate the appropriate value.
+                // We try to grab an empty optional first since there is a good chance we're dealing with an Optional<T>.
+                defaultValue = _dtoEmptyOptionals.GetValueOrDefault(type) ?? Activator.CreateInstance(type);
+            }
+
+            return defaultValue;
+        }
+
+        // Polyfill default parameters for Optional<T> properties.
+        if (_dtoEmptyOptionals.TryGetValue(type, out defaultValue))
+        {
+            return defaultValue;
+        }
+
+        // Otherwise, we have no default value.
+        return default;
     }
 
     /// <summary>

--- a/Remora.Rest/Json/Internal/DTOPropertyInfo.cs
+++ b/Remora.Rest/Json/Internal/DTOPropertyInfo.cs
@@ -19,9 +19,7 @@ namespace Remora.Rest.Json.Internal;
 /// <param name="WriteName">The name used when writing this property.</param>
 /// <param name="Writer">A delegate that writes the property.</param>
 /// <param name="AllowsNull">Whether this property allows null.</param>
-/// <param name="DefaultValue">
-/// null, if this property is required, otherwise its default value (= default of <see cref="Optional{TValue}"/>).
-/// </param>
+/// <param name="DefaultValue">Empty, if this property is required. Otherwise its default value.</param>
 /// <param name="Options">The serializer options used when serializing this property.</param>
 /// <param name="ReadIndex">
 /// The index of this property in the _readProperties array. Has no meaning when writing the object to JSON.
@@ -33,7 +31,7 @@ internal sealed record DTOPropertyInfo
     string WriteName,
     DTOPropertyWriter Writer,
     bool AllowsNull,
-    object? DefaultValue,
+    Optional<object?> DefaultValue,
     JsonSerializerOptions Options,
     int ReadIndex
 );


### PR DESCRIPTION
# Summary

This combines the original handling of implicit `Optional<T>` default values in the DTO converter with the new handling through default parameter values. 

This should not change behavior, but only avoids an additional dictionary look-up per missing property.

I trust that there are tests that assert the behavior was correct; I ran the tests and none of them are failing.

# Changes

This essentially moves the recently added logic in the constructor of `BoundDataObjectConverter` to the `CreateConverter` method of `DataObjectConverter` and merges it with the existing `GetDefaultValueForType` logic, thus replacing it with `GetDefaultValueForParameter`.

The new logic is essentially, for each property:
- Try to grab an associated constructor parameter.
- If a parameter is found, and it has a default value set, uses this value. For value type parameters, if this value is null, this tries to grab a correct empty `Optional<T>` in case it is an optional, otherwise constructs the default value for that via `Activator`, as the code in the BoundDTOConverter did.
- Otherwise, tries to grab a correct empty `Optional<T>` based on the property type.
- Otherwise, there is no default parameter.
