### PR TITLE
object initializer based object construction

### DIFF
--- a/Remora.Rest/Json/Internal/BoundDataObjectConverter.cs
+++ b/Remora.Rest/Json/Internal/BoundDataObjectConverter.cs
@@ -49,7 +49,6 @@ internal sealed class BoundDataObjectConverter<T> : JsonConverter<T>
         DTOPropertyInfo[] writeProperties,
         DTOPropertyInfo[] readProperties
     )
-        : this(dtoFactory, allowExtraProperties, writeProperties, readProperties)
     {
         _dtoFactory = dtoFactory;
         _allowExtraProperties = allowExtraProperties;

--- a/Remora.Rest/Json/Internal/BoundDataObjectConverter.cs
+++ b/Remora.Rest/Json/Internal/BoundDataObjectConverter.cs
@@ -54,12 +54,8 @@ internal sealed class BoundDataObjectConverter<T> : JsonConverter<T>
         DTOPropertyInfo[] writeProperties,
         DTOPropertyInfo[] readProperties
     )
+        : this(dtoFactory, allowExtraProperties, writeProperties, readProperties)
     {
-        _dtoFactory = dtoFactory;
-        _allowExtraProperties = allowExtraProperties;
-        _writeProperties = writeProperties;
-        _readProperties = readProperties;
-
         var constructorParameters = chosenConstructor.GetParameters();
         for (var i = 0; i < chosenConstructor.GetParameters().Length; ++i)
         {
@@ -84,6 +80,27 @@ internal sealed class BoundDataObjectConverter<T> : JsonConverter<T>
                 defaultValue
             );
         }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundDataObjectConverter{T}"/> class.
+    /// </summary>
+    /// <param name="dtoFactory">The DTO factory.</param>
+    /// <param name="allowExtraProperties">Whether extra undefined properties should be allowed.</param>
+    /// <param name="writeProperties">Properties relevant when writing the DTO to JSON.</param>
+    /// <param name="readProperties">Properties relevant when reading the DTO from JSON.</param>
+    public BoundDataObjectConverter
+    (
+        ObjectFactory<T> dtoFactory,
+        bool allowExtraProperties,
+        DTOPropertyInfo[] writeProperties,
+        DTOPropertyInfo[] readProperties
+    )
+    {
+        _dtoFactory = dtoFactory;
+        _allowExtraProperties = allowExtraProperties;
+        _writeProperties = writeProperties;
+        _readProperties = readProperties;
 
         _readPropertiesByName = _readProperties
             .SelectMany(p => p.ReadNames.Select((n, i) => (IsPrimary: i == 0, n, DTOProperty: p)))

--- a/Remora.Rest/Json/Reflection/ConstructorInitializationInfo.cs
+++ b/Remora.Rest/Json/Reflection/ConstructorInitializationInfo.cs
@@ -1,0 +1,75 @@
+﻿//
+//  SPDX-FileName: ConstructorInitializationInfo.cs
+//  SPDX-FileCopyrightText: Copyright (c) Jarl Gullberg
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Remora.Rest.Json.Reflection;
+
+/// <summary>
+/// Represents the information required to initialize a DTO via its constructor.
+/// </summary>
+internal class ConstructorInitializationInfo : IInitializationInfo
+{
+    /// <inheritdoc/>
+    public Type TargetType { get; init; }
+
+    /// <summary>
+    /// Gets the exact constructor used to create objects.
+    /// </summary>
+    public ConstructorInfo Constructor { get; init; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConstructorInitializationInfo"/> class.
+    /// </summary>
+    /// <param name="constructor">The constructor used to create objects.</param>
+    public ConstructorInitializationInfo
+    (
+        ConstructorInfo constructor
+    )
+    {
+        if (constructor.DeclaringType is null)
+        {
+            throw new ArgumentException
+            (
+                "Constructor does not belong to a type",
+                nameof(constructor)
+            );
+        }
+
+        this.TargetType = constructor.DeclaringType;
+        this.Constructor = constructor;
+    }
+
+    /// <inheritdoc/>
+    public ObjectFactory<T> CreateObjectFactory<T>()
+    {
+        var arguments = Expression.Parameter(typeof(object[]), "arguments");
+
+        var parameters = this.Constructor.GetParameters()
+            .Select((p, i) => Expression.Convert
+                (
+                    Expression.ArrayIndex(arguments, Expression.Constant(i)),
+                    p.ParameterType
+                )
+            );
+
+        /*
+         * (object[] arguments) => new constructor(
+         *     (Param0Type) arguments[0],
+         *     (Param1Type) arguments[1],
+         *     ...
+         * );
+         */
+        return Expression.Lambda<ObjectFactory<T>>
+        (
+            Expression.New(this.Constructor, parameters),
+            arguments
+        ).Compile();
+    }
+}

--- a/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
+++ b/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
@@ -56,58 +56,27 @@ internal delegate void DTOPropertyWriter(Utf8JsonWriter writer, DTOPropertyInfo 
 internal static class ExpressionFactoryUtilities
 {
     /// <summary>
-    /// Creates an <see cref="ObjectFactory{T}"/> for the given type <typeparamref name="T"/> using the constructor
-    /// <paramref name="constructor"/>.
+    /// Creates an <see cref="ObjectFactory{T}"/> for the given type <typeparamref name="T"/>.
     /// </summary>
-    /// <param name="constructor">The constructor to be used to create the instance.</param>
+    /// <param name="initialization">The necessary information to create this object.</param>
     /// <typeparam name="T">The type of the instance to create.</typeparam>
     /// <returns>A factory that can be used to create instances of the specified type.</returns>
     /// <exception cref="ArgumentException">
     /// If the type <typeparamref name="T"/> is not assignable to the declaring type of the constructor, or the
     /// constructor does not belong to a type.
     /// </exception>
-    public static ObjectFactory<T> CreateFactory<T>(ConstructorInfo constructor)
+    public static ObjectFactory<T> CreateFactory<T>(IInitializationInfo initialization)
     {
-        if (constructor.DeclaringType == null)
-        {
-            throw new ArgumentException
-            (
-                "Constructor does not belong to a type",
-                nameof(constructor)
-            );
-        }
-
-        if (!typeof(T).IsAssignableFrom(constructor.DeclaringType))
+        if (!typeof(T).IsAssignableFrom(initialization.TargetType))
         {
             throw new ArgumentException
             (
                 $"Constructor does not belong to a type corresponding to {nameof(T)}",
-                nameof(constructor)
+                nameof(initialization)
             );
         }
 
-        var arguments = Expression.Parameter(typeof(object[]), "arguments");
-
-        var parameters = constructor.GetParameters()
-            .Select((p, i) => Expression.Convert
-                (
-                    Expression.ArrayIndex(arguments, Expression.Constant(i)),
-                    p.ParameterType
-                )
-            );
-
-        /*
-         * (object[] arguments) => new constructor(
-         *     (Param0Type) arguments[0],
-         *     (Param1Type) arguments[1],
-         *     ...
-         * );
-         */
-        return Expression.Lambda<ObjectFactory<T>>
-        (
-            Expression.New(constructor, parameters),
-            arguments
-        ).Compile();
+        return initialization.CreateObjectFactory<T>();
     }
 
     /// <summary>

--- a/Remora.Rest/Json/Reflection/IInitializationInfo.cs
+++ b/Remora.Rest/Json/Reflection/IInitializationInfo.cs
@@ -1,0 +1,28 @@
+﻿//
+//  SPDX-FileName: IInitializationInfo.cs
+//  SPDX-FileCopyrightText: Copyright (c) Jarl Gullberg
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+using System;
+
+namespace Remora.Rest.Json.Reflection;
+
+/// <summary>
+/// Represents an abstraction for the information required to initialize a DTO.
+/// </summary>
+internal interface IInitializationInfo
+{
+    /// <summary>
+    /// Gets the type being initialized.
+    /// </summary>
+    Type TargetType { get; }
+
+    /// <summary>
+    /// Creates a new <seealso cref="ObjectFactory{T}"/> for this type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to create.</typeparam>
+    /// <returns>The <seealso cref="ObjectFactory{T}"/> for this type. Results need not be cached, and it
+    /// is advised to cache them at callsites.</returns>
+    ObjectFactory<T> CreateObjectFactory<T>();
+}

--- a/Remora.Rest/Json/Reflection/ObjectInitializationInfo.cs
+++ b/Remora.Rest/Json/Reflection/ObjectInitializationInfo.cs
@@ -1,0 +1,63 @@
+﻿//
+//  SPDX-FileName: ObjectInitializationInfo.cs
+//  SPDX-FileCopyrightText: Copyright (c) Jarl Gullberg
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Remora.Rest.Json.Reflection;
+
+/// <summary>
+/// Represents the information required to initialize a DTO via its setters.
+/// </summary>
+internal class ObjectInitializationInfo : IInitializationInfo
+{
+    /// <inheritdoc/>
+    public Type TargetType { get; }
+
+    /// <summary>
+    /// Gets the visible properties on this DTO.
+    /// </summary>
+    public IReadOnlyList<PropertyInfo> Properties { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectInitializationInfo"/> class.
+    /// </summary>
+    /// <param name="target">The target type being initialized.</param>
+    /// <param name="visibleProperties">The visible properties on this type.</param>
+    public ObjectInitializationInfo
+    (
+        Type target,
+        IReadOnlyList<PropertyInfo> visibleProperties
+    )
+    {
+        this.TargetType = target;
+        this.Properties = visibleProperties;
+    }
+
+    /// <inheritdoc/>
+    public ObjectFactory<T> CreateObjectFactory<T>()
+    {
+        var arguments = Expression.Parameter(typeof(object[]), "arguments");
+        var constructor = Expression.New(this.TargetType);
+
+        var bindings = this.Properties
+            .Select
+            (
+                (property, index) => Expression.Bind
+                (
+                    property,
+                    Expression.ArrayIndex(arguments, Expression.Constant(index))
+                )
+            );
+
+        var init = Expression.MemberInit(constructor, bindings);
+
+        return Expression.Lambda<ObjectFactory<T>>(init, arguments).Compile();
+    }
+}

--- a/Remora.Rest/Json/Reflection/ObjectInitializationInfo.cs
+++ b/Remora.Rest/Json/Reflection/ObjectInitializationInfo.cs
@@ -52,7 +52,11 @@ internal class ObjectInitializationInfo : IInitializationInfo
                 (property, index) => Expression.Bind
                 (
                     property,
-                    Expression.ArrayIndex(arguments, Expression.Constant(index))
+                    Expression.Convert
+                    (
+                        Expression.ArrayIndex(arguments, Expression.Constant(index)),
+                        property.PropertyType
+                    )
                 )
             );
 

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/IOldStyleData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/IOldStyleData.cs
@@ -1,0 +1,23 @@
+﻿//
+//  SPDX-FileName: IOldStyleData.cs
+//  SPDX-FileCopyrightText: Copyright (c) Jarl Gullberg
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data interface for implementation by an old-style, pre-primary-constructor type.
+/// </summary>
+internal interface IOldStyleData
+{
+    /// <summary>
+    /// Gets an inconsequential value.
+    /// </summary>
+    string Value { get; }
+
+    /// <summary>
+    /// Gets an equally inconsequential other value.
+    /// </summary>
+    int OtherValue { get; }
+}

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/OldStyleData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/OldStyleData.cs
@@ -1,0 +1,19 @@
+﻿//
+//  SPDX-FileName: OldStyleData.cs
+//  SPDX-FileCopyrightText: Copyright (c) Jarl Gullberg
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// An old style data object.
+/// </summary>
+public sealed class OldStyleData : IOldStyleData
+{
+    /// <inheritdoc/>
+    required public string Value { get; init; }
+
+    /// <inheritdoc/>
+    required public int OtherValue { get; init; }
+}

--- a/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
+++ b/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
@@ -29,6 +29,9 @@
       <Compile Update="Data\DataObjects\IConstructorArgumentData.cs">
         <DependentUpon>ConstructorArgumentData.cs</DependentUpon>
       </Compile>
+	  <Compile Update="Data\DataObjects\IOldStyleData.cs">
+	  	<DependentUpon>OldStyleData.cs</DependentUpon>
+	  </Compile>
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
+++ b/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
@@ -29,9 +29,9 @@
       <Compile Update="Data\DataObjects\IConstructorArgumentData.cs">
         <DependentUpon>ConstructorArgumentData.cs</DependentUpon>
       </Compile>
-	  <Compile Update="Data\DataObjects\IOldStyleData.cs">
-	  	<DependentUpon>OldStyleData.cs</DependentUpon>
-	  </Compile>
+      <Compile Update="Data\DataObjects\IOldStyleData.cs">
+        <DependentUpon>OldStyleData.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Rest.Tests/Tests/Json/DataObjectConverterTests.cs
+++ b/Tests/Remora.Rest.Tests/Tests/Json/DataObjectConverterTests.cs
@@ -747,4 +747,36 @@ public class DataObjectConverterTests
         var serialized = JsonDocument.Parse(JsonSerializer.Serialize(value, jsonOptions));
         JsonAssert.Equivalent(expectedPayload, serialized);
     }
+
+    /// <summary>
+    /// Tests whether the converter can correctly deserialize into an old-style object without a constructor.
+    /// </summary>
+    [Fact]
+    public void CanDeserializeOldStyleObjects()
+    {
+        var services = new ServiceCollection()
+            .Configure<JsonSerializerOptions>
+            (
+                json =>
+                {
+                    json.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+                    json.AddDataObjectConverter<IOldStyleData, OldStyleData>();
+                })
+            .BuildServiceProvider();
+
+        var jsonOptions = services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
+
+        var payload =
+            """
+            {
+                "value": "ooga",
+                "other_value": 4
+            }
+            """;
+
+        OldStyleData deserialized = JsonSerializer.Deserialize<OldStyleData>(payload, jsonOptions)!;
+
+        Assert.Equal("ooga", deserialized.Value);
+        Assert.Equal(4, deserialized.OtherValue);
+    }
 }


### PR DESCRIPTION
Enables using data types that are not records using primary constructors with `DataObjectConverter`, such as the following scenarios:

~~~cs
public sealed record IWantPeopleToUseObjectInitializers : IData
{
    public required string Data { get; init; }
}
~~~
and
~~~cs
public class IExistInAnOlderCodebase : IData
{
    public required string Data { get; init; }
}
~~~

let me know if and what tests i should add/whether i should update anything else to go along with these changes/...