### PR TITLE
Expose "Frontend" Json converters

### DIFF
--- a/Remora.Rest/Json/NullableConverter.cs
+++ b/Remora.Rest/Json/NullableConverter.cs
@@ -7,14 +7,16 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
-namespace Remora.Rest.Json.Internal;
+namespace Remora.Rest.Json;
 
 /// <summary>
 /// Converts from to and from <see cref="Nullable{T}"/>.
 /// </summary>
 /// <typeparam name="TValue">The inner nullable value.</typeparam>
-internal class NullableConverter<TValue> : JsonConverter<TValue?>
+[PublicAPI]
+public class NullableConverter<TValue> : JsonConverter<TValue?>
     where TValue : struct
 {
     /// <inheritdoc />

--- a/Remora.Rest/Json/NullableConverterFactory.cs
+++ b/Remora.Rest/Json/NullableConverterFactory.cs
@@ -7,14 +7,16 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using Remora.Rest.Extensions;
 
-namespace Remora.Rest.Json.Internal;
+namespace Remora.Rest.Json;
 
 /// <summary>
 /// Creates instances of <see cref="NullableConverter{TValue}"/>.
 /// </summary>
-internal class NullableConverterFactory : JsonConverterFactory
+[PublicAPI]
+public class NullableConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)

--- a/Remora.Rest/Json/OneOfConverter.cs
+++ b/Remora.Rest/Json/OneOfConverter.cs
@@ -11,17 +11,19 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using OneOf;
 using Remora.Rest.Core;
 using Remora.Rest.Extensions;
 
-namespace Remora.Rest.Json.Internal;
+namespace Remora.Rest.Json;
 
 /// <summary>
 /// Converts instances of <see cref="IOneOf"/> to and from JSON.
 /// </summary>
 /// <typeparam name="TOneOf">The OneOf type.</typeparam>
-internal class OneOfConverter<TOneOf> : JsonConverter<TOneOf>
+[PublicAPI]
+public class OneOfConverter<TOneOf> : JsonConverter<TOneOf>
     where TOneOf : IOneOf
 {
     /// <summary>

--- a/Remora.Rest/Json/OneOfConverterFactory.cs
+++ b/Remora.Rest/Json/OneOfConverterFactory.cs
@@ -8,14 +8,16 @@ using System;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using OneOf;
 
-namespace Remora.Rest.Json.Internal;
+namespace Remora.Rest.Json;
 
 /// <summary>
 /// Creates OneOf converters.
 /// </summary>
-internal class OneOfConverterFactory : JsonConverterFactory
+[PublicAPI]
+public class OneOfConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)

--- a/Remora.Rest/Json/OptionalConverter.cs
+++ b/Remora.Rest/Json/OptionalConverter.cs
@@ -7,15 +7,17 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using Remora.Rest.Core;
 
-namespace Remora.Rest.Json.Internal;
+namespace Remora.Rest.Json;
 
 /// <summary>
 /// Converts optional fields to their JSON representation.
 /// </summary>
 /// <typeparam name="TValue">The underlying type.</typeparam>
-internal class OptionalConverter<TValue> : JsonConverter<Optional<TValue?>>
+[PublicAPI]
+public class OptionalConverter<TValue> : JsonConverter<Optional<TValue?>>
 {
     /// <inheritdoc />
     public override Optional<TValue?> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/Remora.Rest/Json/OptionalConverterFactory.cs
+++ b/Remora.Rest/Json/OptionalConverterFactory.cs
@@ -8,14 +8,16 @@ using System;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using Remora.Rest.Core;
 
-namespace Remora.Rest.Json.Internal;
+namespace Remora.Rest.Json;
 
 /// <summary>
 /// Creates converters for <see cref="Optional{TValue}"/>.
 /// </summary>
-internal class OptionalConverterFactory : JsonConverterFactory
+[PublicAPI]
+public class OptionalConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)


### PR DESCRIPTION
As discussed on Discord:

This will allow consumers of this library to manually add these converters. Useful in the case of using this library with ASP.NET Core (especially minimal API's) where the `JsonSerializerOptions` is wrapped in a `JsonOptions` type