### PR TITLE
Ensure Content is read if ContentLength Header is null

### DIFF
--- a/Remora.Rest/Http/RestHttpClient.cs
+++ b/Remora.Rest/Http/RestHttpClient.cs
@@ -651,7 +651,7 @@ public class RestHttpClient<TError> : IRestHttpClient
         }
 
         // See if we have a JSON error to get some more details from
-        if (response.Content.Headers.ContentLength is not > 0)
+        if (response.Content.Headers.ContentLength == 0)
         {
             return new HttpResultError(response.StatusCode, response.ReasonPhrase);
         }


### PR DESCRIPTION
This fixes an error that content of an error is not read if the ContentLength Header is null. Content must be read before checking the content length header. Brings the error handling in line with the success handling that also checks against 0.

I have tested this on the same code that produced the error in #26 and it now functions correctly. More tests would likely to be helpful to add to catch errors like this in future or other errors that exist with the same condition elsewhere in the code but I wouldn't know where to start with that.