### PR TITLE
Fix analyzer tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,15 +4,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="JsonDocumentPath" Version="1.0.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="OneOf" Version="3.0.263" />
     <PackageVersion Include="Remora.Results" Version="7.4.1" />
     <PackageVersion Include="Remora.Results.Analyzers" Version="1.0.2" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
-    <PackageVersion Include="xunit.assert" Version="2.6.2" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.1" />
+    <PackageVersion Include="xunit.assert" Version="2.6.6" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
   </ItemGroup>

--- a/Remora.Rest/Http/RestHttpClient.cs
+++ b/Remora.Rest/Http/RestHttpClient.cs
@@ -651,7 +651,7 @@ public class RestHttpClient<TError> : IRestHttpClient
         }
 
         // See if we have a JSON error to get some more details from
-        if (response.Content.Headers.ContentLength is not > 0)
+        if (response.Content.Headers.ContentLength == 0)
         {
             return new HttpResultError(response.StatusCode, response.ReasonPhrase);
         }

--- a/Tests/Remora.Rest.Core.Analyzers.Tests/Remora.Rest.Core.Analyzers.Tests.csproj
+++ b/Tests/Remora.Rest.Core.Analyzers.Tests/Remora.Rest.Core.Analyzers.Tests.csproj
@@ -6,9 +6,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Rest.Core.Analyzers.Tests/TestBases/OptionalAnalyzerTests.cs
+++ b/Tests/Remora.Rest.Core.Analyzers.Tests/TestBases/OptionalAnalyzerTests.cs
@@ -8,7 +8,6 @@ using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Remora.Rest.Core.Analyzers.Tests.TestBases;
 
@@ -16,7 +15,7 @@ namespace Remora.Rest.Core.Analyzers.Tests.TestBases;
 /// Serves as a base class for Optional-targeted analyzer tests.
 /// </summary>
 /// <typeparam name="TAnalyzer">The analyzer under test.</typeparam>
-public abstract class OptionalAnalyzerTests<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+public abstract class OptionalAnalyzerTests<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     /// <summary>
@@ -26,9 +25,9 @@ public abstract class OptionalAnalyzerTests<TAnalyzer> : CSharpAnalyzerTest<TAna
     {
         this.ReferenceAssemblies = new ReferenceAssemblies
         (
-            "net7.0",
-            new PackageIdentity("Microsoft.NETCore.App.Ref", "7.0.0"),
-            Path.Combine("ref", "net7.0")
+            "net8.0",
+            new PackageIdentity("Microsoft.NETCore.App.Ref", "8.0.1"),
+            Path.Combine("ref", "net8.0")
         );
 
         this.TestState.AdditionalReferences.Add(typeof(Optional<>).Assembly);

--- a/Tests/Remora.Rest.Core.Analyzers.Tests/TestBases/OptionalCodeFixTests.cs
+++ b/Tests/Remora.Rest.Core.Analyzers.Tests/TestBases/OptionalCodeFixTests.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Remora.Rest.Core.Analyzers.Tests.TestBases;
 
@@ -18,7 +17,7 @@ namespace Remora.Rest.Core.Analyzers.Tests.TestBases;
 /// </summary>
 /// <typeparam name="TAnalyzer">The analyzer under test.</typeparam>
 /// <typeparam name="TCodeFix">The code fix under test.</typeparam>
-public abstract class OptionalCodeFixTests<TAnalyzer, TCodeFix> : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+public abstract class OptionalCodeFixTests<TAnalyzer, TCodeFix> : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     where TAnalyzer : DiagnosticAnalyzer, new()
     where TCodeFix : CodeFixProvider, new()
 {
@@ -29,9 +28,9 @@ public abstract class OptionalCodeFixTests<TAnalyzer, TCodeFix> : CSharpCodeFixT
     {
         this.ReferenceAssemblies = new ReferenceAssemblies
         (
-            "net7.0",
-            new PackageIdentity("Microsoft.NETCore.App.Ref", "7.0.0"),
-            Path.Combine("ref", "net7.0")
+            "net8.0",
+            new PackageIdentity("Microsoft.NETCore.App.Ref", "8.0.1"),
+            Path.Combine("ref", "net8.0")
         );
 
         this.TestState.AdditionalReferences.Add(typeof(Optional<int>).Assembly);


### PR DESCRIPTION
Fixing the issue described here https://github.com/Remora/Remora.Rest/pull/27#issuecomment-1938068100 I switched the *.Xunit packages for the default ones like the package devs suggest and bumped the minor versions of the other packages in the process to ensure it was all up to date. I also had to change the Microsoft.NETCore.App.Ref to the net8.0 version.